### PR TITLE
feat(products): implement URL-based modal state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Here is a link to the [Final Result (sample)](https://fe-test.intellixio.com/)
    - Download the **zipped file** of your "assessment" branch (not the main branch).
    - Submit your PR link, the zipped project, and the deployed app link (Vercel, Netlify, etc.) using this **Google Form**: [Submit Your Work](https://docs.google.com/forms/d/e/1FAIpQLScL2ZsrFJ48E2D2BJ1MJ-wfeOBMMPibz7SAXai94o_dkiaaYg/viewform?usp=sf_link).
 
+#### Complete assessment 
+- v-0.0.1
+
 ---
 
 We look forward to reviewing your work!# assessment

--- a/src/app/user-agent/page.tsx
+++ b/src/app/user-agent/page.tsx
@@ -1,7 +1,11 @@
 import { UserAgent } from "@/views/userAgent";
+import { headers } from "next/headers";
 
 const UserAgentRoot = () => {
-  return <UserAgent />;
+  const headersList = headers();
+  const userAgent = headersList.get("user-agent");
+
+  return <UserAgent initialUserAgent={userAgent || "No user agent available"} />;
 };
 
 export default UserAgentRoot;

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,39 +1,30 @@
-import { useState, useMemo, useCallback } from "react";
-import { PaginationConfig, PaginationResult } from "@/types";
-import { calculateTotalPages } from "@/utils/pagination/calculateTotalPages";
-import { getPaginatedItems } from "@/utils/pagination/getPaginatedItems";
-import { getNextPage } from "@/utils/pagination/getNextPage";
+import { useState, useCallback } from 'react';
 
-export const usePagination = <T>({
-  items,
-  itemsPerPage,
-  initialPage = 1,
-}: PaginationConfig<T>): PaginationResult<T> => {
-  const [currentPage, setCurrentPage] = useState<number>(initialPage);
+interface UsePaginationProps<T> {
+  items: T[];
+  itemsPerPage: number;
+}
 
-  const totalPages = useMemo(
-    () => calculateTotalPages(items.length, itemsPerPage),
-    [items, itemsPerPage]
-  );
+export function usePagination<T>({ items, itemsPerPage }: UsePaginationProps<T>) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(items.length / itemsPerPage);
 
-  const paginatedItems = useMemo(
-    () => getPaginatedItems(items, currentPage, itemsPerPage),
-    [items, currentPage, itemsPerPage]
-  );
+  const handlePageChange = useCallback((direction: "next" | "prev") => {
+    setCurrentPage(prev => {
+      if (direction === "next" && prev < totalPages) return prev + 1;
+      if (direction === "prev" && prev > 1) return prev - 1;
+      return prev;
+    });
+  }, [totalPages]);
 
-  const handlePageChange = useCallback(
-    (direction: "next" | "prev") => {
-      setCurrentPage((prevPage) =>
-        getNextPage(prevPage, direction, totalPages)
-      );
-    },
-    [totalPages]
-  );
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedItems = items.slice(startIndex, startIndex + itemsPerPage);
 
   return {
     currentPage,
+    setCurrentPage,
     totalPages,
     paginatedItems,
     handlePageChange,
   };
-};
+}

--- a/src/views/products/products.tsx
+++ b/src/views/products/products.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Product } from "@/types";
 import { ProductModal } from "@/views/products/productModal/productModal";
 import { BackToHome } from "@/components/backToHome/backToHome";
@@ -10,21 +11,109 @@ import { usePagination } from "@/hooks/usePagination";
 import { PRODUCTS_DATA } from "@/data/productsData";
 
 export const Products: React.FC = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   const {
     currentPage,
     totalPages,
     paginatedItems: paginatedProducts,
     handlePageChange,
+    setCurrentPage,
   } = usePagination({ items: PRODUCTS_DATA, itemsPerPage: 5 });
+
+  // Handle browser back/forward buttons
+  useEffect(() => {
+    const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const productId = params.get('productId');
+      const page = params.get('page');
+
+      if (page) {
+        const pageNum = parseInt(page);
+        if (pageNum >= 1 && pageNum <= totalPages) {
+          setCurrentPage(pageNum);
+        }
+      }
+
+      if (productId) {
+        const product = PRODUCTS_DATA.find(p => p.id.toString() === productId);
+        if (product) {
+          setSelectedProduct(product);
+          setIsModalOpen(true);
+        }
+      } else {
+        setSelectedProduct(null);
+        setIsModalOpen(false);
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [totalPages, setCurrentPage]);
+
+  // Initialize state from URL on mount
+  useEffect(() => {
+    const productId = searchParams.get('productId');
+    const page = searchParams.get('page');
+
+    if (page) {
+      const pageNum = parseInt(page);
+      if (pageNum >= 1 && pageNum <= totalPages) {
+        setCurrentPage(pageNum);
+      }
+    }
+
+    if (productId) {
+      const product = PRODUCTS_DATA.find(p => p.id.toString() === productId);
+      if (product) {
+        setSelectedProduct(product);
+        setIsModalOpen(true);
+      }
+    }
+  }, [searchParams, totalPages, setCurrentPage]);
+
+  const updateURL = useCallback((productId?: string | null, page: number = currentPage) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (productId) {
+      params.set('productId', productId);
+    } else {
+      params.delete('productId');
+    }
+
+    if (page > 1) {
+      params.set('page', page.toString());
+    } else {
+      params.delete('page');
+    }
+
+    const newURL = params.toString()
+      ? `?${params.toString()}`
+      : '';
+
+    router.push(`/products${newURL}`, { scroll: false });
+  }, [router, currentPage, searchParams]);
 
   const handleOpenModal = useCallback((product: Product) => {
     setSelectedProduct(product);
-  }, []);
+    setIsModalOpen(true);
+    updateURL(product.id.toString());
+  }, [updateURL]);
 
   const handleCloseModal = useCallback(() => {
     setSelectedProduct(null);
-  }, []);
+    setIsModalOpen(false);
+    updateURL(null);
+  }, [updateURL]);
+
+  const handlePageChangeWithURL = useCallback((direction: "next" | "prev") => {
+    const newPage = direction === "next" ? currentPage + 1 : currentPage - 1;
+    handlePageChange(direction);
+    updateURL(selectedProduct?.id?.toString() || null, newPage);
+  }, [currentPage, handlePageChange, updateURL, selectedProduct]);
 
   return (
     <div>
@@ -34,9 +123,9 @@ export const Products: React.FC = () => {
       <PaginationControls
         currentPage={currentPage}
         totalPages={totalPages}
-        onPageChange={handlePageChange}
+        onPageChange={handlePageChangeWithURL}
       />
-      {selectedProduct && (
+      {isModalOpen && selectedProduct && (
         <ProductModal product={selectedProduct} onClose={handleCloseModal} />
       )}
     </div>

--- a/src/views/products/products.tsx
+++ b/src/views/products/products.tsx
@@ -1,133 +1,13 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Product } from "@/types";
-import { ProductModal } from "@/views/products/productModal/productModal";
-import { BackToHome } from "@/components/backToHome/backToHome";
-import { ProductList } from "@/views/products/productList/productList";
-import { PaginationControls } from "@/views/products/paginationControls/paginationControls";
-import { usePagination } from "@/hooks/usePagination";
-import { PRODUCTS_DATA } from "@/data/productsData";
+import React, { Suspense, } from "react";
+import ProductsContent from "./productsContent/productsContent";
+
 
 export const Products: React.FC = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const {
-    currentPage,
-    totalPages,
-    paginatedItems: paginatedProducts,
-    handlePageChange,
-    setCurrentPage,
-  } = usePagination({ items: PRODUCTS_DATA, itemsPerPage: 5 });
-
-  // Handle browser back/forward buttons
-  useEffect(() => {
-    const handlePopState = () => {
-      const params = new URLSearchParams(window.location.search);
-      const productId = params.get('productId');
-      const page = params.get('page');
-
-      if (page) {
-        const pageNum = parseInt(page);
-        if (pageNum >= 1 && pageNum <= totalPages) {
-          setCurrentPage(pageNum);
-        }
-      }
-
-      if (productId) {
-        const product = PRODUCTS_DATA.find(p => p.id.toString() === productId);
-        if (product) {
-          setSelectedProduct(product);
-          setIsModalOpen(true);
-        }
-      } else {
-        setSelectedProduct(null);
-        setIsModalOpen(false);
-      }
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [totalPages, setCurrentPage]);
-
-  // Initialize state from URL on mount
-  useEffect(() => {
-    const productId = searchParams.get('productId');
-    const page = searchParams.get('page');
-
-    if (page) {
-      const pageNum = parseInt(page);
-      if (pageNum >= 1 && pageNum <= totalPages) {
-        setCurrentPage(pageNum);
-      }
-    }
-
-    if (productId) {
-      const product = PRODUCTS_DATA.find(p => p.id.toString() === productId);
-      if (product) {
-        setSelectedProduct(product);
-        setIsModalOpen(true);
-      }
-    }
-  }, [searchParams, totalPages, setCurrentPage]);
-
-  const updateURL = useCallback((productId?: string | null, page: number = currentPage) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (productId) {
-      params.set('productId', productId);
-    } else {
-      params.delete('productId');
-    }
-
-    if (page > 1) {
-      params.set('page', page.toString());
-    } else {
-      params.delete('page');
-    }
-
-    const newURL = params.toString()
-      ? `?${params.toString()}`
-      : '';
-
-    router.push(`/products${newURL}`, { scroll: false });
-  }, [router, currentPage, searchParams]);
-
-  const handleOpenModal = useCallback((product: Product) => {
-    setSelectedProduct(product);
-    setIsModalOpen(true);
-    updateURL(product.id.toString());
-  }, [updateURL]);
-
-  const handleCloseModal = useCallback(() => {
-    setSelectedProduct(null);
-    setIsModalOpen(false);
-    updateURL(null);
-  }, [updateURL]);
-
-  const handlePageChangeWithURL = useCallback((direction: "next" | "prev") => {
-    const newPage = direction === "next" ? currentPage + 1 : currentPage - 1;
-    handlePageChange(direction);
-    updateURL(selectedProduct?.id?.toString() || null, newPage);
-  }, [currentPage, handlePageChange, updateURL, selectedProduct]);
-
   return (
-    <div>
-      <BackToHome />
-      <ProductList products={paginatedProducts} onOpenModal={handleOpenModal} />
-      <div className="h-4" />
-      <PaginationControls
-        currentPage={currentPage}
-        totalPages={totalPages}
-        onPageChange={handlePageChangeWithURL}
-      />
-      {isModalOpen && selectedProduct && (
-        <ProductModal product={selectedProduct} onClose={handleCloseModal} />
-      )}
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <ProductsContent />
+    </Suspense>
   );
 };

--- a/src/views/products/productsContent/productsContent.tsx
+++ b/src/views/products/productsContent/productsContent.tsx
@@ -1,0 +1,139 @@
+"use client";
+import { BackToHome } from "@/components/backToHome/backToHome";
+import { PRODUCTS_DATA } from "@/data/productsData";
+import { usePagination } from "@/hooks/usePagination";
+import { Product } from "@/types";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useCallback } from "react";
+import { PaginationControls } from "../paginationControls/paginationControls";
+import { ProductList } from "../productList/productList";
+import { ProductModal } from "../productModal";
+
+const ProductsContent: React.FC = () => {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const {
+        currentPage,
+        totalPages,
+        paginatedItems: paginatedProducts,
+        handlePageChange,
+        setCurrentPage,
+    } = usePagination({ items: PRODUCTS_DATA, itemsPerPage: 5 });
+
+    useEffect(() => {
+        const handlePopState = () => {
+            const params = new URLSearchParams(window.location.search);
+            const productId = params.get("productId");
+            const page = params.get("page");
+
+            if (page) {
+                const pageNum = parseInt(page);
+                if (pageNum >= 1 && pageNum <= totalPages) {
+                    setCurrentPage(pageNum);
+                }
+            }
+
+            if (productId) {
+                const product = PRODUCTS_DATA.find((p) => p.id.toString() === productId);
+                if (product) {
+                    setSelectedProduct(product);
+                    setIsModalOpen(true);
+                }
+            } else {
+                setSelectedProduct(null);
+                setIsModalOpen(false);
+            }
+        };
+
+        window.addEventListener("popstate", handlePopState);
+        return () => window.removeEventListener("popstate", handlePopState);
+    }, [totalPages, setCurrentPage]);
+
+    useEffect(() => {
+        const productId = searchParams.get("productId");
+        const page = searchParams.get("page");
+
+        if (page) {
+            const pageNum = parseInt(page);
+            if (pageNum >= 1 && pageNum <= totalPages) {
+                setCurrentPage(pageNum);
+            }
+        }
+
+        if (productId) {
+            const product = PRODUCTS_DATA.find((p) => p.id.toString() === productId);
+            if (product) {
+                setSelectedProduct(product);
+                setIsModalOpen(true);
+            }
+        }
+    }, [searchParams, totalPages, setCurrentPage]);
+
+    const updateURL = useCallback(
+        (productId?: string | null, page: number = currentPage) => {
+            const params = new URLSearchParams(searchParams.toString());
+
+            if (productId) {
+                params.set("productId", productId);
+            } else {
+                params.delete("productId");
+            }
+
+            if (page > 1) {
+                params.set("page", page.toString());
+            } else {
+                params.delete("page");
+            }
+
+            const newURL = params.toString() ? `?${params.toString()}` : "";
+
+            // Navigate to the new URL without the unsupported `scroll` option
+            router.push(`/products${newURL}`);
+        },
+        [router, currentPage, searchParams]
+    );
+
+    const handleOpenModal = useCallback(
+        (product: Product) => {
+            setSelectedProduct(product);
+            setIsModalOpen(true);
+            updateURL(product.id.toString());
+        },
+        [updateURL]
+    );
+
+    const handleCloseModal = useCallback(() => {
+        setSelectedProduct(null);
+        setIsModalOpen(false);
+        updateURL(null);
+    }, [updateURL]);
+
+    const handlePageChangeWithURL = useCallback(
+        (direction: "next" | "prev") => {
+            const newPage = direction === "next" ? currentPage + 1 : currentPage - 1;
+            handlePageChange(direction);
+            updateURL(selectedProduct?.id?.toString() || null, newPage);
+        },
+        [currentPage, handlePageChange, updateURL, selectedProduct]
+    );
+
+    return (
+        <div>
+            <BackToHome />
+            <ProductList products={paginatedProducts} onOpenModal={handleOpenModal} />
+            <div className="h-4" />
+            <PaginationControls
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChangeWithURL}
+            />
+            {isModalOpen && selectedProduct && (
+                <ProductModal product={selectedProduct} onClose={handleCloseModal} />
+            )}
+        </div>
+    );
+};
+export default ProductsContent

--- a/src/views/userAgent/userAgent.tsx
+++ b/src/views/userAgent/userAgent.tsx
@@ -1,24 +1,17 @@
-"use client";
-
 import { BackToHome } from "@/components/backToHome/backToHome";
-import { useUserAgentContext } from "@/components/providers/userAgentProvider";
 
-export const UserAgent = () => {
-  const { userAgent } = useUserAgentContext();
+type UserAgentProps = {
+  initialUserAgent: string;
+};
 
+export const UserAgent: React.FC<UserAgentProps> = ({ initialUserAgent }) => {
   return (
     <div>
       <BackToHome />
-
-      {userAgent && (
-        <div className="flex font-mono font-semibold text-sm">
-          <div className="border p-2">UserAgent</div>
-
-          <div className="border p-2">{userAgent}</div>
-        </div>
-      )}
-
-      {!userAgent && <div>No user agent</div>}
+      <div className="flex font-mono font-semibold text-sm">
+        <div className="border p-2">UserAgent</div>
+        <div className="border p-2">{initialUserAgent}</div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- Add URL state persistence for product modal
- Handle browser back/forward navigation
- Maintain modal state across page reloads
- Synchronize pagination state with URL parameters
- Add isModalOpen state for better modal visibility control

This commit ensures that:
- Product modal state is reflected in URL parameters
- Modal state persists after page reload
- Browser navigation history works correctly
- URL parameters stay in sync with page state

### 2. **Print User Agent Without JavaScript**

- Updated `UserAgentRoot` to fetch `user-agent` from server-side headers using `next/headers`.
- Modified `UserAgent` component to accept and render `initialUserAgent` from SSR.
- Ensured compatibility when JavaScript is disabled by relying on server-rendered output.
- Added fallback message ("No user agent available") for missing `user-agent` header.
- Retained flexibility for client-side enhancements if JavaScript is enabled.